### PR TITLE
fix: WebSocket proxy not forwarding ping/pong data

### DIFF
--- a/hass_web_proxy_lib/__init__.py
+++ b/hass_web_proxy_lib/__init__.py
@@ -190,9 +190,9 @@ class WebsocketProxyView(ProxyView):
                 elif msg.type == aiohttp.WSMsgType.BINARY:
                     await ws_out.send_bytes(msg.data)
                 elif msg.type == aiohttp.WSMsgType.PING:
-                    await ws_out.ping()
+                    await ws_out.ping(msg.data)
                 elif msg.type == aiohttp.WSMsgType.PONG:
-                    await ws_out.pong()
+                    await ws_out.pong(msg.data)
             except ConnectionResetError:
                 return
 


### PR DESCRIPTION
The ping/pong frame data is important depending on the implementation.

When a ping is sent with data, pong must be replied with the same data, as per the WebSocket RFC.

Thus, depending on what is being proxied, this can cause the keepalive mechanism not to work and therefore cause stuff like unexpected disconnections.

For more context, see https://github.com/home-assistant/supervisor/pull/6144.